### PR TITLE
Replace “módulo” with “misión” and refresh financial icons

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -13,14 +13,14 @@
   transition: all 0.6s ease-in-out;
 }
 
-#module-badges div {
+#mission-badges div {
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-#module-badges div:hover {
+#mission-badges div:hover {
   transform: translateY(-2px);
 }
 
-#module-badges div.bg-purple-100 {
+#mission-badges div.bg-purple-100 {
   box-shadow: 0 0 8px rgba(128, 90, 213, 0.3); /* subtle glow for unlocked badges */
 }

--- a/el-dinero-que-se-va.html
+++ b/el-dinero-que-se-va.html
@@ -35,12 +35,16 @@
       <div class="text-6xl mb-4">💳</div>
       <h1 class="text-4xl font-bold mb-2">el que se va ("¿volando?") 💨</h1>
       <p class="text-lg">cómo se escapa el dinero: gastos, presupuesto y las herramientas que usas para moverlo</p>
-	  <div class="mt-4 text-sm flex flex-col items-center space-y-2">
-	    <p class="font-medium">misión 3 de 6 · 15 min</p>
-  
-	    <!-- Container for badges earned in this module -->
-	    <div id="module-badges" class="flex space-x-2"></div>
-	  </div>
+          <div class="mt-4 text-sm flex flex-col items-center space-y-2">
+            <div class="text-4xl flex gap-4">
+              <span>💳</span>
+              <span>💳⚠️</span>
+            </div>
+            <p class="font-medium">misión 3 de 6 · 15 min</p>
+
+            <!-- Container for badges earned in esta misión -->
+            <div id="mission-badges" class="flex space-x-2"></div>
+          </div>
     </div>
   </section>
 
@@ -71,19 +75,19 @@
     </p>
     <div class="grid md:grid-cols-3 gap-6 mb-12">
       <div class="bg-white p-8 rounded-xl shadow-md border-t-4 border-purple-500 hover:shadow-xl transition text-center">
-        <div class="text-4xl mb-3">🏠</div>
+        <div class="text-4xl mb-3">📆</div>
         <h4 class="text-xl font-bold mb-2">gastos fijos</h4>
         <p class="text-gray-600 mb-2">los que se repiten cada mes y casi nunca cambian</p>
         <p class="text-purple-600 font-semibold">netflix, abono transporte, gimnasio, Spotify</p>
       </div>
       <div class="bg-white p-8 rounded-xl shadow-md border-t-4 border-teal-500 hover:shadow-xl transition text-center">
-        <div class="text-4xl mb-3">🎲</div>
+        <div class="text-4xl mb-3">🛍️</div>
         <h4 class="text-xl font-bold mb-2">gastos variables</h4>
         <p class="text-gray-600 mb-2">los que cambian según lo que hagas</p>
         <p class="text-purple-600 font-semibold">ropa, comida, salir al cine</p>
       </div>
       <div class="bg-white p-8 rounded-xl shadow-md border-t-4 border-pink-500 hover:shadow-xl transition text-center">
-        <div class="text-4xl mb-3">☕</div>
+        <div class="text-4xl mb-3">🐜</div>
         <h4 class="text-xl font-bold mb-2">gastos hormiga</h4>
         <p class="text-gray-600 mb-2">parecen pequeños, pero pueden sumar mucho</p>
         <p class="text-purple-600 font-semibold">2€ al día = 720€ al año = un iPhone</p>
@@ -129,13 +133,13 @@
     </p>
     <div class="grid md:grid-cols-2 gap-6 mb-12">
       <div class="bg-white rounded-xl shadow-md p-8 border-t-4 border-purple-500 hover:shadow-xl transition text-center">
-        <div class="text-4xl mb-3">🏦</div>
+        <div class="text-4xl mb-3">💶</div>
         <h4 class="text-xl font-bold mb-2">cuenta corriente</h4>
         <p class="text-gray-600 mb-2">la cuenta básica donde entra tu dinero y desde la que pagas el día a día</p>
         <p class="text-purple-600 font-semibold">sirve para bizum, transferencias, recibos</p>
       </div>
       <div class="bg-white rounded-xl shadow-md p-8 border-t-4 border-teal-500 hover:shadow-xl transition text-center">
-        <div class="text-4xl mb-3">💰</div>
+        <div class="text-4xl mb-3">🐖💶</div>
         <h4 class="text-xl font-bold mb-2">cuenta de ahorro</h4>
         <p class="text-gray-600 mb-2">pensada para guardar dinero que no gastas inmediatamente; a veces puede ser parte de la cuenta corriente</p>
         <p class="text-purple-600 font-semibold">en muchas de ellas ganas un (pequeño) interés</p>
@@ -151,7 +155,7 @@
         <p class="text-purple-600 font-semibold">si tienes 50€, solo podrás gastar hasta ahí</p>
       </div>
       <div class="bg-white rounded-xl shadow-md p-8 border-t-4 border-red-500 hover:shadow-xl transition text-center transform hover:scale-105">
-        <div class="text-4xl mb-3">💳</div>
+        <div class="text-4xl mb-3">💳⚠️</div>
         <h4 class="text-xl font-bold mb-2">tarjeta de crédito</h4>
         <p class="text-gray-600 mb-2">parece cómodo, pero si no pagas a tiempo te cobran intereses</p>
         <p class="text-purple-600 font-semibold">compras 100€ → si no pagas cuando toca, terminas pagando 120€</p>

--- a/index.html
+++ b/index.html
@@ -59,20 +59,20 @@
       <p class="text-lg md:text-2xl mb-8">
         aprende a ganar, gastar y ahorrar sin caer en trampas
       </p>
-      <a href="#modulos" class="inline-flex items-center gap-2 bg-white text-purple-600 px-6 py-3 rounded-full font-semibold hover:bg-gray-100 transition">
+      <a href="#misiones" class="inline-flex items-center gap-2 bg-white text-purple-600 px-6 py-3 rounded-full font-semibold hover:bg-gray-100 transition">
         ▶ empieza ya
       </a>
     </div>
   </section>
 
-  <!-- MÓDULOS EN GRID -->
-  <section id="modulos" class="py-16 max-w-6xl mx-auto px-6">
+  <!-- MISIONES EN GRID -->
+  <section id="misiones" class="py-16 max-w-6xl mx-auto px-6">
     <h2 class="text-3xl font-bold mb-4 text-center">completa 6 misiones para dominar tu dinero</h2>
     <p class="text-center text-gray-600 mb-10">cada misión te lleva menos de 20 min y te renta porque acabas teniendo más para lo que te importa</p>
 
     <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
 
-<!-- Módulo 1 -->
+<!-- Misión 1 -->
 <a href="usar-bien-el-dinero-importa-tanto-como-ganarlo-bien.html" class="block transform hover:scale-105 transition cursor-pointer">
   <div class="bg-white shadow-lg rounded-xl p-6 relative hover:shadow-2xl text-center flex flex-col">
     <div class="absolute top-4 left-4 w-8 h-8 flex items-center justify-center bg-purple-600 text-white rounded-full font-bold">1</div>
@@ -83,7 +83,7 @@
   </div>
 </a>
 
-<!-- Módulo 2 -->
+<!-- Misión 2 -->
 <a href="el-dinero-que-entra.html" class="block transform hover:scale-105 transition cursor-pointer">
   <div class="bg-white shadow-lg rounded-xl p-6 relative hover:shadow-2xl text-center flex flex-col">
     <div class="absolute top-4 left-4 w-8 h-8 flex items-center justify-center bg-purple-600 text-white rounded-full font-bold">2</div>
@@ -94,7 +94,7 @@
   </div>
 </a>
 
-<!-- Módulo 3 -->
+<!-- Misión 3 -->
 <a href="el-dinero-que-se-va.html" class="block transform hover:scale-105 transition cursor-pointer">
   <div class="bg-white shadow-lg rounded-xl p-6 relative hover:shadow-2xl text-center flex flex-col">
     <div class="absolute top-4 left-4 w-8 h-8 flex items-center justify-center bg-purple-600 text-white rounded-full font-bold">3</div>
@@ -105,7 +105,7 @@
   </div>
 </a>
 
-<!-- Módulo 4 -->
+<!-- Misión 4 -->
 <a href="ahorrar-con-objetivos-la-magia-del-interes-compuesto-y-empezar-a-invertir.html" class="block transform hover:scale-105 transition cursor-pointer">
   <div class="bg-white shadow-lg rounded-xl p-6 relative hover:shadow-2xl text-center flex flex-col">
     <div class="absolute top-4 left-4 w-8 h-8 flex items-center justify-center bg-purple-600 text-white rounded-full font-bold">4</div>
@@ -116,7 +116,7 @@
   </div>
 </a>
 
-<!-- Módulo 5 -->
+<!-- Misión 5 -->
 <a href="publicidad-redes-sociales-y-seguridad-digital-para-proteger-tu-dinero.html" class="block transform hover:scale-105 transition cursor-pointer">
   <div class="bg-white shadow-lg rounded-xl p-6 relative hover:shadow-2xl text-center flex flex-col">
     <div class="absolute top-4 left-4 w-8 h-8 flex items-center justify-center bg-purple-600 text-white rounded-full font-bold">5</div>
@@ -127,7 +127,7 @@
   </div>
 </a>
 
-<!-- Módulo 6 -->
+<!-- Misión 6 -->
 <a href="prestamos-y-creditos-entiende-por-que-el-dinero-prestado-nunca-sale-gratis.html" class="block transform hover:scale-105 transition cursor-pointer">
   <div class="bg-white shadow-lg rounded-xl p-6 relative hover:shadow-2xl text-center flex flex-col">
     <div class="absolute top-4 left-4 w-8 h-8 flex items-center justify-center bg-purple-600 text-white rounded-full font-bold">6</div>
@@ -174,7 +174,7 @@
       <div>
         <h4 class="font-bold mb-3">enlaces</h4>
         <ul class="space-y-2 text-sm">
-          <li><a href="#modulos" class="hover:underline">módulos</a></li>
+          <li><a href="#misiones" class="hover:underline">misiones</a></li>
           <li><a href="#" onclick="toggleModal()" class="hover:underline">apúntate gratis</a></li>
         </ul>
       </div>

--- a/js/progress.js
+++ b/js/progress.js
@@ -1,6 +1,6 @@
 /* ==========
    Progress System for Financial Literacy Course
-   Works across all modules
+   Works across all misiones
    ========== */
 
 function loadProgress() {
@@ -17,11 +17,11 @@ function addPoints(amount) {
   saveProgress(progress);
 }
 
-function markModuleComplete(moduleId) {
+function markMissionComplete(missionId) {
   const progress = loadProgress();
-  progress.modulesCompleted = progress.modulesCompleted || [];
-  if (!progress.modulesCompleted.includes(moduleId)) {
-    progress.modulesCompleted.push(moduleId);
+  progress.missionsCompleted = progress.missionsCompleted || [];
+  if (!progress.missionsCompleted.includes(missionId)) {
+    progress.missionsCompleted.push(missionId);
     saveProgress(progress);
   }
 }
@@ -84,22 +84,22 @@ const BADGES = {
 /* ==========
    RENDER BADGES
    ========== */
-function renderModuleBadges(moduleId) {
+function renderMissionBadges(missionId) {
   const progress = loadProgress();
-  const container = document.getElementById("module-badges");
+  const container = document.getElementById("mission-badges");
   if (!container) return;
 
   container.innerHTML = "";
 
-  // Define which badges belong to which module
-  const moduleBadgeMap = {
-    "modulo-3": ["detective_gastos", "ant_killer", "debit_defender"],
-    "modulo-4": ["ahorro_aventurero", "inversion_explorador"],
-    "modulo-5": ["seguridad_guardian"],
-    "modulo-6": ["deuda_domador"],
+  // Define which badges belong to which misión
+  const missionBadgeMap = {
+    "mision-3": ["detective_gastos", "ant_killer", "debit_defender"],
+    "mision-4": ["ahorro_aventurero", "inversion_explorador"],
+    "mision-5": ["seguridad_guardian"],
+    "mision-6": ["deuda_domador"],
   };
 
-  const relevantBadges = moduleBadgeMap[moduleId] || [];
+  const relevantBadges = missionBadgeMap[missionId] || [];
   const earnedBadges = (progress.badges || []);
 
   relevantBadges.forEach(badgeId => {
@@ -128,4 +128,4 @@ function renderModuleBadges(moduleId) {
 }
 
 
-document.addEventListener("DOMContentLoaded", renderModuleBadges);
+document.addEventListener("DOMContentLoaded", renderMissionBadges);

--- a/js/quiz.js
+++ b/js/quiz.js
@@ -1,6 +1,6 @@
 document.addEventListener('DOMContentLoaded', () => {
   const quizContainers = document.querySelectorAll('.space-y-10 > div');
-  const QUIZ_STORAGE_KEY = 'quizProgress-module3';
+  const QUIZ_STORAGE_KEY = 'quizProgress-mision3';
 
   // Load saved progress or default to empty object
   const savedProgress = JSON.parse(localStorage.getItem(QUIZ_STORAGE_KEY) || '{}');

--- a/js/reto.js
+++ b/js/reto.js
@@ -3,7 +3,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   if (retoButton) {
     retoButton.addEventListener("click", () => {
-      markModuleComplete(3); // Module ID for "el dinero que se va"
+      markMissionComplete(3); // Mission ID for "el dinero que se va"
       unlockBadge("ant_killer");
 
       const final = document.getElementById("final-section");
@@ -27,7 +27,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
       // Toast notification
       const toast = document.createElement("div");
-      toast.textContent = "🎉 ¡Reto completado! Ahora puedes continuar al siguiente módulo.";
+      toast.textContent = "🎉 ¡Reto completado! Ahora puedes continuar a la siguiente misión.";
       toast.className = "fixed bottom-5 right-5 bg-purple-600 text-white px-4 py-2 rounded shadow-lg";
       document.body.appendChild(toast);
       setTimeout(() => toast.remove(), 3000);


### PR DESCRIPTION
## Summary
- Swap out course navigation and references to use "misión" instead of "módulo".
- Revamp spending, account, and card sections with euro-friendly and differentiated icons.
- Insert debit and credit card icons in the hero and adjust scripts/CSS to new mission naming.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c698e7ce94832e83e1c7108d8dd83d